### PR TITLE
Remove rogue apostrophe

### DIFF
--- a/js/servicegenerator.js
+++ b/js/servicegenerator.js
@@ -380,7 +380,7 @@ module.exports = function ServiceGenerator() {
                         "Community Supportive Living Systems",
                         "CommunityHealth - Englewood",
                         "CommunityHealth - West Town",
-                        "Cook County - Children’s Advocacy Center",
+                        "Cook County - Children's Advocacy Center",
                         "Cook County - Englewood Health Center",
                         "Cook County - Fantus Health Center",
                         "Cook County - John Sengstacke Health Center",

--- a/www/js/main.concat.js
+++ b/www/js/main.concat.js
@@ -7275,7 +7275,7 @@ module.exports = function ServiceGenerator() {
                         "Community Supportive Living Systems",
                         "CommunityHealth - Englewood",
                         "CommunityHealth - West Town",
-                        "Cook County - Children’s Advocacy Center",
+                        "Cook County - Children's Advocacy Center",
                         "Cook County - Englewood Health Center",
                         "Cook County - Fantus Health Center",
                         "Cook County - John Sengstacke Health Center",

--- a/www/js/main.min.js
+++ b/www/js/main.min.js
@@ -7240,7 +7240,7 @@ module.exports = function ServiceGenerator() {
                         "Community Supportive Living Systems",
                         "CommunityHealth - Englewood",
                         "CommunityHealth - West Town",
-                        "Cook County - Children’s Advocacy Center",
+                        "Cook County - Children's Advocacy Center",
                         "Cook County - Englewood Health Center",
                         "Cook County - Fantus Health Center",
                         "Cook County - John Sengstacke Health Center",


### PR DESCRIPTION
- Apostrope was showing up as a missing character symbol
